### PR TITLE
INFRA-32: Lint Only Changed Files

### DIFF
--- a/linterconfigs/java/style.gradle.kts
+++ b/linterconfigs/java/style.gradle.kts
@@ -41,3 +41,30 @@ if (gradle.startParameter.taskNames
         enabled = false
     }
 }
+
+fun getChangedFiles(): List<File> {
+    val sourceBranchProp: String? by project
+    val targetBranchProp: String? by project
+    val sourceBranch: String? = if (sourceBranchProp.isNullOrEmpty()) "" else sourceBranchProp
+    val targetBranch: String? = if (targetBranchProp.isNullOrEmpty()) "master" else targetBranchProp
+
+    return "git diff --name-status --diff-filter=dr $targetBranch $sourceBranch"
+            .trim().runCommand().trim().split("\n")
+            .filter { it.isNotEmpty() }
+            .map { filename ->
+                println("Filename: $filename")
+                val scrubbedPath: String = """\w\s+(.+)""".toRegex().find(filename)?.groupValues?.get(1)!!
+                file("$projectDir${File.separator}$scrubbedPath")
+            }.toList()
+}
+
+fun String.runCommand(): String {
+    val proc: Process = ProcessBuilder(*this.split(" ").toTypedArray())
+            .directory(projectDir)
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectError(ProcessBuilder.Redirect.PIPE)
+            .start()
+
+    proc.waitFor(1, TimeUnit.MINUTES)
+    return proc.inputStream.bufferedReader().readText()
+}

--- a/linterconfigs/java/style.gradle.kts
+++ b/linterconfigs/java/style.gradle.kts
@@ -20,11 +20,20 @@ configure<CheckstyleExtension> {
     toolVersion = "8.28"
     configFile = rootProject.file("$projectDir/gradle/nextraq_checkstyle.xml")
 }
+tasks.withType(Checkstyle::class) {
+    source(projectDir.absolutePath)
+    classpath = files()
+}
 
 configure<SpotlessExtension> {
     java {
         eclipse().configFile("$projectDir/gradle/eclipse-java-nextraq-style.xml")
         endWithNewline()
+    }
+}
+tasks {
+    register<Checkstyle>("checkstyleChanged") {
+        include(*(getChangedFiles().map { it.toRelativeString(file(".")) }.toTypedArray()))
     }
 }
 


### PR DESCRIPTION
This PR adds functionality to lint only changed files with Checkstyle. Unfortunately, Spotless was giving me trouble with this, but I am in contact with the Spotless team and will add this functionality once they come through. A [ticket](https://nextraq.atlassian.net/browse/INFRA-34) has been filed to address this at a later date.