### PR TITLE
Quick .markdownlint.yaml fixes

### DIFF
--- a/linterconfigs/markdown/.markdownlint.yaml
+++ b/linterconfigs/markdown/.markdownlint.yaml
@@ -22,7 +22,9 @@ no-multiple-blanks: true
                                                                # spaces after the break.
 line-length:
     line_length: 120
-
+    tables: false # Except tables from this rule to preserve their formatting (but still avoid tables where possible)
+    code_blocks: false # Except code blocks for demonstration purposes, but you should still strive to fit code blocks
+                       # within the line limit.
 commands-show-output: true # Triggers when bash code is preceded by $, unless command output is displayed
 no-missing-space-atx: true
 no-multiple-space-atx: true


### PR DESCRIPTION
When fixing the MD files in the styleguide repo, there were a few issues encountered involving demonstrations. Specifically, there was a table demonstration in a code block that was too long. Tables and code blocks were excepted from the line length rule to help preserve table formatting. You should still avoid tables though.