### PR TITLE
Fix MD Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,21 @@
 
 ## Table of Contents
 
-1.   [NexTraq](#nextraq)
-     1.   [Modifications](#modifications)
-          1.   [General](#general)
-          1.   [JavaScript](#javascript)
-     1.   [Formatting Tools](#formatting-tools)
-          1.   [IDE Google Style Config](#ide-google-style-config)
-          1.   [google-java-format](#google-java-format)
-          1.   [ESLint](#eslint)
-          1.   [Markdown](#markdown)
-               1.   [markdownlint](#markdownlint)
-               1.   [remark](#remark)
-               1.   [Prettier](#prettier)
-               1.   [Markdown Navigator](#markdown-navigator)
-     1.   [Future Work](#future-work)
-1.   [Google Style Guides](#google-style-guides)
+1.  [NexTraq](#nextraq)
+     1.  [Modifications](#modifications)
+          1.  [General](#general)
+          1.  [JavaScript](#javascript)
+     1.  [Formatting Tools](#formatting-tools)
+          1.  [IDE Google Style Config](#ide-google-style-config)
+          1.  [google-java-format](#google-java-format)
+          1.  [ESLint](#eslint)
+          1.  [Markdown](#markdown)
+               1.  [markdownlint](#markdownlint)
+               1.  [remark](#remark)
+               1.  [Prettier](#prettier)
+               1.  [Markdown Navigator](#markdown-navigator)
+     1.  [Future Work](#future-work)
+1.  [Google Style Guides](#google-style-guides)
 
 ## NexTraq
 
@@ -205,27 +205,26 @@ format, on XML instance document formatting, and on elements vs. attributes.
 
 The style guides in this project are licensed under the CC-By 3.0 License, which
 encourages you to share these documents. See
-[https://creativecommons.org/licenses/by/3.0/][ccl] for more details.
+[ccl](https://creativecommons.org/licenses/by/3.0/)for more details.
 
 The following Google style guides live outside of this project: [Go Code Review
 Comments][go] and [Effective Dart][dart].
 
-<a rel="license" href="https://creativecommons.org/licenses/by/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/3.0/88x31.png" /></a>
-
-[cpp]: https://google.github.io/styleguide/cppguide.html
+[![Creative Commons](https://i.creativecommons.org/l/by/3.0/88x31.png)](https://creativecommons.org/licenses/by/3.0/)
+[cpp]: <https://google.github.io/styleguide/cppguide.html>
 [objc]: google/objcguide.md
-[java]: https://google.github.io/styleguide/javaguide.html
-[py]: https://google.github.io/styleguide/pyguide.html
-[r]: https://google.github.io/styleguide/Rguide.html
-[sh]: https://google.github.io/styleguide/shell.xml
-[htmlcss]: https://google.github.io/styleguide/htmlcssguide.html
-[js]: https://google.github.io/styleguide/jsguide.html
-[angular]: https://google.github.io/styleguide/angularjs-google-style.html
-[cl]: https://google.github.io/styleguide/lispguide.xml
-[vim]: https://google.github.io/styleguide/vimscriptguide.xml
-[cpplint]: https://github.com/google/styleguide/tree/gh-pages/cpplint
-[emacs]: https://raw.githubusercontent.com/google/styleguide/gh-pages/google-c-style.el
-[xml]: https://google.github.io/styleguide/xmlstyle.html
-[go]: https://golang.org/wiki/CodeReviewComments
-[dart]: https://www.dartlang.org/guides/language/effective-dart
-[ccl]: https://creativecommons.org/licenses/by/3.0/
+[java]: <https://google.github.io/styleguide/javaguide.html>
+[py]: <https://google.github.io/styleguide/pyguide.html>
+[r]: <https://google.github.io/styleguide/Rguide.html>
+[sh]: <https://google.github.io/styleguide/shell.xml>
+[htmlcss]: <https://google.github.io/styleguide/htmlcssguide.html>
+[js]: <https://google.github.io/styleguide/jsguide.html>
+[angular]: <https://google.github.io/styleguide/angularjs-google-style.html>
+[cl]: <https://google.github.io/styleguide/lispguide.xml>
+[vim]: <https://google.github.io/styleguide/vimscriptguide.xml>
+[cpplint]: <https://github.com/google/styleguide/tree/gh-pages/cpplint>
+[emacs]: <https://raw.githubusercontent.com/google/styleguide/gh-pages/google-c-style.el>
+[xml]: <https://google.github.io/styleguide/xmlstyle.html>
+[go]: <https://golang.org/wiki/CodeReviewComments>
+[dart]: <https://www.dartlang.org/guides/language/effective-dart>
+[ccl]: <https://creativecommons.org/licenses/by/3.0/>

--- a/docguide/README.md
+++ b/docguide/README.md
@@ -1,10 +1,10 @@
 # Google documentation guide
 
-* [Markdown styleguide](style.md)
-* [Best practices](best_practices.md)
-* [README files](READMEs.md)
-* [Philosophy](philosophy.md)
+*   [Markdown styleguide](style.md)
+*   [Best practices](best_practices.md)
+*   [README files](READMEs.md)
+*   [Philosophy](philosophy.md)
 
 ## See also
 
-* [How to update this guide](https://goto.google.com/doc-guide), for Googlers.
+*   [How to update this guide](https://goto.google.com/doc-guide), for Googlers.

--- a/docguide/READMEs.md
+++ b/docguide/READMEs.md
@@ -16,12 +16,12 @@ GitHub and Gitiles renders it when you browse the directory.
 For example, the file /README.md is rendered when you view the contents of the
 containing directory:
 
-https://github.com/google/styleguide/tree/gh-pages
+<https://github.com/google/styleguide/tree/gh-pages>
 
 Also `README.md` at `HEAD` ref is rendered by Gitiles when displaying repository
 index:
 
-https://gerrit.googlesource.com/gitiles/
+<https://gerrit.googlesource.com/gitiles/>
 
 ## Guidelines
 
@@ -50,8 +50,8 @@ following information:
 3.  **Status**: whether this package/library is deprecated, or not for general
     release, etc.
 4.  **More info**: where to go for more detailed documentation, such as:
-     * An overview.md file for more detailed conceptual information.
-     * Any API documentation for using this package/library.
+     *   An overview.md file for more detailed conceptual information.
+     *   Any API documentation for using this package/library.
 
 ## Example
 

--- a/docguide/best_practices.md
+++ b/docguide/best_practices.md
@@ -1,7 +1,7 @@
 # Documentation Best Practices
 
-"Say what you mean, simply and directly." - [Brian Kernighan]
-(https://en.wikipedia.org/wiki/The_Elements_of_Programming_Style)
+"Say what you mean, simply and directly." -
+[Brian Kernighan](https://en.wikipedia.org/wiki/The_Elements_of_Programming_Style)
 
 Contents:
 
@@ -24,8 +24,8 @@ This guide encourages engineers to take ownership of their docs and keep
 them up to date with the same zeal we keep our tests in good order. Strive for
 this.
 
-* Identify what you really need: release docs, API docs, testing guidelines.
-* Delete cruft frequently and in small batches.
+*   Identify what you really need: release docs, API docs, testing guidelines.
+*   Delete cruft frequently and in small batches.
 
 ## Update docs with code
 
@@ -108,8 +108,8 @@ to detailed prose:
 
 3.  **README.md**: A good README.md orients the new user to the directory and
     points to more detailed explanation and user guides:
-    * What is this directory intended to hold?
-    * Which files should the developer look at first? Are some files an API?
-    * Who maintains this directory and where I can learn more?
+    *   What is this directory intended to hold?
+    *   Which files should the developer look at first? Are some files an API?
+    *   Who maintains this directory and where I can learn more?
 
     See the [README.md guidelines](READMEs.md).

--- a/docguide/philosophy.md
+++ b/docguide/philosophy.md
@@ -16,56 +16,56 @@ Contents:
 
 ## Radical simplicity
 
-* **Scalability and interoperability** are more important than a menagerie of
+*   **Scalability and interoperability** are more important than a menagerie of
   unessential features. Scale comes from simplicity, speed, and ease.
   Interoperability comes from unadorned, digestible content.
 
-* **Fewer distractions** make for better writing and more productive reading.
+*   **Fewer distractions** make for better writing and more productive reading.
 
-* **New features should never interfere with the simplest use case** and should
+*   **New features should never interfere with the simplest use case** and should
   remain invisible to users who don't need them.
 
-* **This guide is designed for the average engineer** -- the busy,
+*   **This guide is designed for the average engineer** -- the busy,
   just-want-to-go-back-to-coding engineer. Large and complex documentation is
   possible but not the primary focus.
 
-* **Minimizing context switching makes people happier.** Engineers should be
+*   **Minimizing context switching makes people happier.** Engineers should be
   able to interact with documentation using the same tools they use to read and
   write code.
 
 ## Readable source text
 
-* **Plain text not only suffices, it is superior**. Markdown itself is not
+*   **Plain text not only suffices, it is superior**. Markdown itself is not
   essential to this formula, but it is the best and most widely supported
   solution right now. HTML is generally not encouraged.
 
-* **Content and presentation should not mingle**. It should always be possible
+*   **Content and presentation should not mingle**. It should always be possible
   to ditch the renderer and read the essential information at source. Users
   should never have to touch the presentation layer if they don't want to.
 
-* **Portability and future-proofing leave room for the unimagined integrations
+*   **Portability and future-proofing leave room for the unimagined integrations
   to come**, and are best achieved by keeping the source as human-readable as
   possible.
 
-* **Static content is better than dynamic**, because content should not depend
+*   **Static content is better than dynamic**, because content should not depend
   on the features of any one server. However, **fresh is better than stale**. We
   strive to balance these needs.
 
 ## Minimum viable documentation
 
-* **Docs thrive when they're treated like tests**: a necessary chore one learns
+*   **Docs thrive when they're treated like tests**: a necessary chore one learns
   to savor because it rewards over time.
   See [Best Practices](best_practices.md).
 
-* **Brief and utilitarian is better than long and exhaustive**. The vast
+*   **Brief and utilitarian is better than long and exhaustive**. The vast
   majority of users need only a small fraction of the author's total knowledge,
   but they need it quickly and often.
 
 ## Better is better than perfect
 
-* **Incremental improvement is better than prolonged debate**. Patience and
+*   **Incremental improvement is better than prolonged debate**. Patience and
   tolerance of imperfection allow projects to evolve organically.
 
-* **Don't lick the cookie, pass the plate**. We're drowning in potentially
+*   **Don't lick the cookie, pass the plate**. We're drowning in potentially
   impactful projects. Choose only those you can really handle and release those
   you can't.

--- a/docguide/style.md
+++ b/docguide/style.md
@@ -7,9 +7,9 @@ possible.
 
 We seek to balance three goals:
 
-1. *Source text is readable and portable.*
-2. *Markdown files are maintainable over time and across teams.*
-3. *The syntax is simple and easy to remember.*
+1.  *Source text is readable and portable.*
+2.  *Markdown files are maintainable over time and across teams.*
+3.  *The syntax is simple and easy to remember.*
 
 Contents:
 
@@ -252,12 +252,10 @@ anyway.
 
 For code quotations longer than a single line, use a codeblock:
 
-<pre>
 ```python
 def Foo(self, bar):
   self.bar = bar
 ```
-</pre>
 
 #### Declare the language
 
@@ -290,12 +288,10 @@ Because most commandline snippets are intended to be copied and pasted directly
 into a terminal, it's best practice to escape any newlines. Use a single
 backslash at the end of the line:
 
-<pre>
 ```shell
 bazel run :target -- --flag --foo=longlonglonglonglongvalue \
---bar=anotherlonglonglonglonglonglonglonglonglonglongvalue
+        --bar=anotherlonglonglonglonglonglonglonglonglonglongvalue
 ```
-</pre>
 
 #### Nest codeblocks within lists
 

--- a/linterconfigs/README.md
+++ b/linterconfigs/README.md
@@ -35,7 +35,9 @@ Run Spotless using the following command:
 ```bash
 gradle spotlessApply
 ```
+
 or
+
 ```bash
 gradlew spotlessApply
 ```
@@ -72,6 +74,7 @@ module.exports = {
 ```
 
 In general, run ESLint checks like so:
+
 ```bash
 yarn eslint --ext .js .
 ```
@@ -107,7 +110,7 @@ gem install mdl
 ```
 
 To run the checks, use the following command:
-    
+
 ```bash
 # TODO: Update with path when cross-repo solution is implemented
 mdl -s <path/to/styleguide>/linterconfigs/markdown/style.rb <file pattern>


### PR DESCRIPTION
This PR makes Markdownlint pass on all MD files in the styleguide repo. Google originals are excluded.